### PR TITLE
Fix constructor being converted to undefined

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -157,7 +157,6 @@ export default class SymbolsPrettifier extends Plugin {
 								{ line: cursor.line, ch: cursor.ch }
 							);
 						} else {
-              debugger;
 							view.editor.replaceRange(
 								`<span class="${replaceCharacter.classes}">${replaceCharacter.transform}</span>`,
 								{ line: cursor.line, ch: from },

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,24 +11,23 @@ interface CharacterMap {
 	[key: string]: string | HTMLObject;
 }
 
-const characterMap: CharacterMap = {
-	'->': '→',
-	'<-': '←',
-	'<->': '↔',
-	'<=>': '⇔',
-	'<=': '⇐',
-	'=>': '⇒',
-	'--': '–',
-	'!important': {
-		transform: '!important',
-		classes: 'symbols-prettifier-important',
-		element: '<span class="symbols-prettifier-important">!important</span>',
-	},
-	'?unclear': {
-		transform: '?unclear',
-		classes: 'symbols-prettifier-unclear',
-		element: '<span class="symbols-prettifier-unclear">?unclear</span>',
-	},
+const characterMap: CharacterMap = Object.create(null);
+characterMap['->'] = '→';
+characterMap['<-'] = '←';
+characterMap['<->'] = '↔';
+characterMap['<=>'] = '⇔';
+characterMap['<='] = '⇐';
+characterMap['=>'] = '⇒';
+characterMap['--'] = '–';
+characterMap['!important'] = {
+  transform: '!important',
+  classes: 'symbols-prettifier-important',
+  element: '<span class="symbols-prettifier-important">!important</span>',
+};
+characterMap['?unclear'] = {
+  transform: '?unclear',
+  classes: 'symbols-prettifier-unclear',
+  element: '<span class="symbols-prettifier-unclear">?unclear</span>',
 };
 
 export default class SymbolsPrettifier extends Plugin {
@@ -158,6 +157,7 @@ export default class SymbolsPrettifier extends Plugin {
 								{ line: cursor.line, ch: cursor.ch }
 							);
 						} else {
+              debugger;
 							view.editor.replaceRange(
 								`<span class="${replaceCharacter.classes}">${replaceCharacter.transform}</span>`,
 								{ line: cursor.line, ch: from },


### PR DESCRIPTION
The issue was that regular property accessing in javascript can inherit from the prototype. 

By default, each object in js has the "object" prototype which has a "constructor" property on it (Which is a function). 

I fixed this by createing the character Map so that it doesn't inherit from the default object.

See https://chat.openai.com/share/acece149-6d4b-457c-9ae9-7fa8a3ec35fc