### PR TITLE
Update README.md - remove unsupported symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With the help of this plugin, it is easier than ever before. This plugin allows 
 
 The easiest way to use the plugin is to install it and then try to type the following symbols. All of these symbols will be prettified:
 
-`->`, `<-`, `<->`, `<=>`, `<=`, `=>`, `?unclear`, `!important`
+`->`, `<-`, `<->`, `<=>`, `<=`, `=>`
 
 ## Development
 


### PR DESCRIPTION
As figured out in #14, support for these symbols was removed in https://github.com/FlorianWoelki/obsidian-symbols-prettifier/commit/03cd990aa14a037b0dd20d4037e83be5630ddc71

Fixes #14