### PR TITLE
fix `<->` symbol rendering problem by prioritizing `<->` in regex

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ export const characterMap: CharacterMap = {
 };
 
 export function getCharacterRegex(): RegExp {
-  return new RegExp("(->|<-|<->|<=>|<=|=>|--|!=|===)", "g");
+  return new RegExp("(<->|->|<-|<=>|<=|=>|--|!=|===)", "g");
 }
 
 export default class SymbolsPrettifier extends Plugin {


### PR DESCRIPTION
As [itismilob](https://github.com/itismilob) suggested in https://github.com/FlorianWoelki/obsidian-symbols-prettifier/issues/13#issuecomment-2432707986 , move `<->` before `<-` should fix issue https://github.com/FlorianWoelki/obsidian-symbols-prettifier/issues/13.